### PR TITLE
fix: account for multiple occurences of the same substring within a word

### DIFF
--- a/substring_reader.rb
+++ b/substring_reader.rb
@@ -1,9 +1,11 @@
 def substrings(word, dictionary)
   sub_hash = Hash.new(0)
+  word = word.downcase
 
   dictionary.each do |sub_str|
-    if word.include?(sub_str.downcase)
-      sub_hash[sub_str] += 1
+    if word.include?(sub_str)
+      occurences = word.scan(sub_str)
+      sub_hash[sub_str.to_sym] += occurences.length
     end
   end
 


### PR DESCRIPTION
The previous implementation will only increment the substring count once. By using the scan method, which returns an array of all the occurences of a sub string, you could increment the count by the array length.

- Check git diff for more info.